### PR TITLE
Github actions fix, py version as string

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Set up Python 3.9
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: "3.9"
       - name: Install Tox and any other packages
         run: pip install tox
       - name: Run Tox


### PR DESCRIPTION
La versió de Python estava posada com a int, i això donava problemes a l'intentar posar la versió 3.10 ja que s'interpretava com a 3.1